### PR TITLE
Das Scaling unter Windows berücksichtigen.

### DIFF
--- a/src/de/muenchen/allg/itd51/wollmux/event/handlers/OnNotifyDocumentEventListener.java
+++ b/src/de/muenchen/allg/itd51/wollmux/event/handlers/OnNotifyDocumentEventListener.java
@@ -1,5 +1,6 @@
 package de.muenchen.allg.itd51.wollmux.event.handlers;
 
+import java.awt.Dimension;
 import java.awt.Insets;
 import java.beans.PropertyChangeEvent;
 import java.lang.reflect.Method;
@@ -159,6 +160,7 @@ public class OnNotifyDocumentEventListener extends BasicEvent
       LOGGER.debug("", e);
     }
 
+    Dimension dimFrame = formController.getFrameSize();
     java.awt.Rectangle frameB = formController.getFrameBounds();
     java.awt.Rectangle maxWindowBounds = formController.getMaxWindowBounds();
     Insets windowInsets = formController.getWindowInsets();
@@ -177,6 +179,7 @@ public class OnNotifyDocumentEventListener extends BasicEvent
       docWidth = maxWindowBounds.width;
     }
     int docY = maxWindowBounds.y + windowInsets.top;
+    docX = (int) (dimFrame.width * formController.getScalingFactor());
     /*
      * Das Subtrahieren von 2*windowInsets.bottom ist ebenfalls eine Heuristik. (siehe weiter oben)
      */

--- a/src/de/muenchen/allg/itd51/wollmux/form/control/FormController.java
+++ b/src/de/muenchen/allg/itd51/wollmux/form/control/FormController.java
@@ -1,5 +1,6 @@
 package de.muenchen.allg.itd51.wollmux.form.control;
 
+import java.awt.Dimension;
 import java.awt.Insets;
 import java.awt.Rectangle;
 import java.awt.event.ActionListener;
@@ -77,6 +78,16 @@ public class FormController
   public Rectangle getMaxWindowBounds()
   {
     return maxWindowBounds;
+  }
+
+  public Dimension getFrameSize()
+  {
+    return gui.getFrameSize();
+  }
+
+  public double getScalingFactor()
+  {
+    return gui.getScalingFactor();
   }
 
   public Insets getWindowInsets()

--- a/src/de/muenchen/allg/itd51/wollmux/form/dialog/GUI.java
+++ b/src/de/muenchen/allg/itd51/wollmux/form/dialog/GUI.java
@@ -3,6 +3,8 @@ package de.muenchen.allg.itd51.wollmux.form.dialog;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Container;
+import java.awt.Dimension;
+import java.awt.GraphicsConfiguration;
 import java.awt.GraphicsEnvironment;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
@@ -14,6 +16,7 @@ import java.awt.event.FocusAdapter;
 import java.awt.event.FocusEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
+import java.awt.geom.AffineTransform;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.EnumMap;
@@ -975,4 +978,17 @@ public class GUI
       });
     }
   }
+
+  public Dimension getFrameSize()
+  {
+    return myFrame.getBounds().getSize();
+  }
+
+  public double getScalingFactor()
+  {
+	  GraphicsConfiguration gc = myFrame.getGraphicsConfiguration();
+	  AffineTransform df = gc.getDefaultTransform();
+	  return df.getScaleX();
+  }
+
 }


### PR DESCRIPTION
Das Javafenster gibt eine Fenstergröße zurück, die das Scaling nicht berücksichtigt.